### PR TITLE
Added tabs to the ui to seperate out metrics

### DIFF
--- a/repo_health/index/static/client/assets/styles/styles.css
+++ b/repo_health/index/static/client/assets/styles/styles.css
@@ -24,3 +24,8 @@
   right: 0;
   margin: auto;
 }
+
+.repo-tabs {
+  background: white;
+  border: 1px solid #e1e1e1;
+}

--- a/repo_health/index/static/client/src/components/utils/base.template.html
+++ b/repo_health/index/static/client/src/components/utils/base.template.html
@@ -1,47 +1,46 @@
 
 <md-content layout-padding layout="row" layout-align="center center">
-  <md-card flex="65">
-      <div layout="column" ng-if="$ctrl.loadingStats" layout-align="center center">
-          {{::$ctrl.loadingMsg}}
-          <div layout="row" class="md-padding">
-            <md-progress-circular md-diameter="96"></md-progress-circular>
-          </div>
+  <md-card flex>
+    <div layout="column" ng-if="$ctrl.loadingStats" layout-align="center center">
+      {{::$ctrl.loadingMsg}}
+      <div layout="row" class="md-padding">
+        <md-progress-circular md-diameter="96"></md-progress-circular>
       </div>
+    </div>
     <div ng-if="!$ctrl.loadingStats">
-        <div ng-repeat="i in $ctrl.numOfStatsSections">
-         <md-card-title ng-if="$first">
-          <md-card-title-text>
-            <span class="md-headline">{{ $ctrl.stats[2 * i].raw_data }}</span>
-            <span class="md-subhead">
-                <b ng-if="$ctrl.stats[2 * i + 1].display_name">{{ $ctrl.stats[2 * i + 1].display_name }}</b>
-                {{ $ctrl.stats[2 * i + 1].raw_data }}
-            </span>
-          </md-card-title-text>
-        </md-card-title>
-        <md-card-content layout="column" ng-if="!$first">
+      <div ng-repeat="i in $ctrl.numOfStatsSections">
+        <md-card-title ng-if="$first">
+        <md-card-title-text>
+          <span class="md-headline">{{ $ctrl.stats[2 * i].raw_data }}</span>
+          <span class="md-subhead">
+            <b ng-if="$ctrl.stats[2 * i + 1].display_name">{{ $ctrl.stats[2 * i + 1].display_name }}</b>
+            {{ $ctrl.stats[2 * i + 1].raw_data }}
+          </span>
+        </md-card-title-text>
+      </md-card-title>
+      <md-card-content layout="column" ng-if="!$first">
+        <div flex><span class="md-title" ng-if="$ctrl.stats[(2 * i)].display_name">{{$ctrl.stats[(2 * i)].display_name}}:</span>
+          {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats[(2 * i)]) }}
+        </div>
+        <div flex>
+          <span class="md-title" ng-if="$ctrl.stats[ (2 * i + 1) ].display_name">
+            {{$ctrl.stats[ (2 * i + 1) ].display_name}}:
+          </span>
+          {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats[ (2 * i + 1) ]) }}
+        </div>
 
-                <div flex><span class="md-title" ng-if="$ctrl.stats[(2 * i)].display_name">{{$ctrl.stats[(2 * i)].display_name}}:</span>
-                    {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats[(2 * i)]) }}
-                </div>
-                <div flex>
-                    <span class="md-title" ng-if="$ctrl.stats[ (2 * i + 1) ].display_name">
-                        {{$ctrl.stats[ (2 * i + 1) ].display_name}}:
-                    </span>
-                    {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats[ (2 * i + 1) ]) }}
-                </div>
+        <!--If we have an odd number of stats and on the last iteration we need to render one more.-->
+        <div flex ng-if="$ctrl.stats.length % 2 != 0 && $last">
+          <span class="md-title" ng-if="$ctrl.stats[$ctrl.stats.length - 1].display_name">
+            {{$ctrl.stats[$ctrl.stats.length-1].display_name}}:
+          </span>
+          {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats.length-1) }}
+        </div>
+    <!--<canvas id="line" class="chart chart-line" chart-data="$ctrl.stats.prs_last_year" chart-labels="$ctrl.labels"-->
+              <!--chart-click="$ctrl.onClick" chart-hover="$ctrl.onHover" chart-series="$ctrl.series" chart-options="$ctrl.options"-->
+              <!--chart-dataset-override="$ctrl.datasetOverride"></canvas>-->
 
-                <!--If we have an odd number of stats and on the last iteration we need to render one more.-->
-                <div flex ng-if="$ctrl.stats.length % 2 != 0 && $last">
-                    <span class="md-title" ng-if="$ctrl.stats[$ctrl.stats.length - 1].display_name">
-                        {{$ctrl.stats[$ctrl.stats.length-1].display_name}}:
-                    </span>
-                    {{ $ctrl.StatsService.getRawDataForChartName($ctrl.stats.length-1) }}
-                </div>
-            <!--<canvas id="line" class="chart chart-line" chart-data="$ctrl.stats.prs_last_year" chart-labels="$ctrl.labels"-->
-                      <!--chart-click="$ctrl.onClick" chart-hover="$ctrl.onHover" chart-series="$ctrl.series" chart-options="$ctrl.options"-->
-                      <!--chart-dataset-override="$ctrl.datasetOverride"></canvas>-->
-
-        </md-card-content>
+      </md-card-content>
     </div>
   </md-card>
 </md-content>

--- a/repo_health/index/static/client/src/main.component.js
+++ b/repo_health/index/static/client/src/main.component.js
@@ -14,11 +14,19 @@ const template = `
   <div layout="row" layout-align="center center">
     <h1 class="md-display-3 text-center">Repo Health Assessment</h1>
   </div>
-  <div layout="row">
-    <div ui-view flex>
-      <div ui-view="repo-details"></div>
-      <div ui-view="pull-req-stats"></div>
-      <div ui-view="issue-stats"></div>
+  <div layout="row" layout-align="center center">
+    <div ui-view flex="65">
+      <md-tabs class="repo-tabs" md-dynamic-height md-border-bottom>
+        <md-tab label="Details">
+          <div ui-view="repo-details"></div>
+        </md-tab>
+        <md-tab label="Pull Request Stats">
+          <div ui-view="pull-req-stats"></div>
+        </md-tab>
+        <md-tab label="Issue Stats">
+          <div ui-view="issue-stats"></div>
+        </md-tab>
+      </md-tabs>
     </div>
   </div>
 `;


### PR DESCRIPTION
The only change in base.template was changing `flex="65"` to `flex`. 2 spaces is how the other templates are done.